### PR TITLE
Add save functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# CHANGELOG.md
+## 1.1.0 (2022-08-27) (released)
+- Add ability store links with reference to a name
+
+## 1.0.2 (2022-08-25)
+- Serialize / deserialize settings
+- Improve error handling
+
+## 1.0.1 (2022-08-10) (released)
+- Clean code and file restructuring
+
+## 1.0.0 (2022-08-08) (released)
+- Configuration of api endpoint
+- Opening data from api endpoint

--- a/README.md
+++ b/README.md
@@ -10,11 +10,16 @@ Opens links in your default browser from a url endpoint or from a cmdline argume
 From url endpoint (in development):
 ```bash
 fl config
-# checks current url endpoint
+# checks current api endpoint
 
 fl config https://my-endpoint-with-links.com
 fl open
 # opens all links received from endpoint
+
+fl save <name> <newline-seperated-links>
+fl open <name>
+# opens links based on name given
+# saving to the same name will overwrite that configuration
 ```
 
 From cmdline:

--- a/src/data/cmd.rs
+++ b/src/data/cmd.rs
@@ -12,6 +12,8 @@ pub enum Commands {
     Config(Config),
     /// Fan out links specified in config into browser.
     Open(Open),
+    /// Give a set of links a name to open at a different time.
+    Save(Save),
 }
 
 #[derive(Args)]
@@ -23,5 +25,12 @@ pub struct Config {
 #[derive(Args)]
 pub struct Open {
     #[clap(value_parser)]
+    pub cmd: Option<String>,
+}
+
+#[derive(Args)]
+pub struct Save {
+    #[clap(value_parser)]
+    pub name: Option<String>,
     pub links: Option<String>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use crate::io::file::{get_config, set_config};
 use crate::io::web::{get_web_body, open_links};
 use clap::Parser;
 use parse::links::parse_text;
+use parse::settings::add_custom_link;
 
 #[tokio::main]
 async fn main() {
@@ -44,32 +45,76 @@ async fn main() {
                 }
             },
         },
-        Commands::Open(arg) => match &arg.links {
+        Commands::Open(arg) => match &arg.cmd {
             // If arguments are passed in, use string instead of url endpoint
             Some(text) => {
-                let links = parse_text(text);
+                let mut links: Vec<&str> = Vec::new();
+                let has_key = match &config.custom_links {
+                    Some(cl) => match cl.contains_key(&text.to_string()) {
+                        true => {
+                            println!("Getting using key: {}", &text);
+                            links = parse_text(&cl.get(text).unwrap());
+                            true
+                        }
+                        false => false,
+                    },
+                    None => false,
+                };
+
+                match has_key {
+                    true => {}
+                    false => {
+                        links = parse_text(text);
+                    }
+                }
                 open_links(links)
             }
             // If no arguments are passed in, load data from url endpoint
             None => match config.api {
                 Some(api) => {
-                    println!("Link found: {}", &api);
                     let web_response = get_web_body(api).await;
                     match web_response {
                         Ok(body) => {
-                            println!("Body found: {}", &body);
                             let links = parse_text(&body);
                             open_links(links)
                         }
                         Err(e) => {
-                            println!("Something went wrong: {}", e)
+                            println!("Something went wrong: {}", e);
                         }
                     }
                 }
                 None => {
-                    println!("Config is not set.")
+                    println!("Config is not set.");
                 }
             },
+        },
+        Commands::Save(args) => match &args.name {
+            Some(name) => match &args.links {
+                Some(links) => {
+                    config = Settings {
+                        custom_links: add_custom_link(
+                            config.custom_links,
+                            (name.to_string(), links.to_string()),
+                        ),
+                        ..config
+                    };
+
+                    match set_config(&config) {
+                        Ok(_) => {
+                            println!("'{}' updated to open '{}'", name, links);
+                        }
+                        Err(e) => {
+                            println!("Error setting config: {}", e);
+                        }
+                    }
+                }
+                None => {
+                    println!("Error: A link must be provided.");
+                }
+            },
+            None => {
+                println!("Error: A name must be provided.")
+            }
         },
     }
 }

--- a/src/parse/settings.rs
+++ b/src/parse/settings.rs
@@ -1,5 +1,6 @@
 use crate::data::settings::Settings;
 use anyhow::Result;
+use std::collections::HashMap;
 
 pub fn from_config(s: String) -> Result<Settings> {
     let deserialized = serde_json::from_str(&s)?;
@@ -9,4 +10,21 @@ pub fn from_config(s: String) -> Result<Settings> {
 pub fn to_config(s: &Settings) -> Result<String> {
     let serialized = serde_json::to_string(&s)?;
     Ok(serialized)
+}
+
+pub fn add_custom_link(
+    l: Option<HashMap<String, String>>,
+    kv: (String, String),
+) -> Option<HashMap<String, String>> {
+    match l {
+        Some(mut hm) => {
+            hm.insert(kv.0, kv.1);
+            Some(hm)
+        }
+        None => {
+            let mut hm = HashMap::new();
+            hm.insert(kv.0, kv.1);
+            Some(hm)
+        }
+    }
 }


### PR DESCRIPTION
Add functionality to save links under a name
These links can be re-opened with by calling open with name eg.

fl save myname "https://mywebsite.com"
fl open myname