### PR TITLE
Add permanent config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,35 @@
-# CHANGELOG.md
-## 1.1.0 (2022-08-27) (released)
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.2.0] - 2023-03-05
+### Added
+- Non-temporary config storage / loading
+
+## [1.1.0] - 2022-08-27
+### Added
 - Add ability store links with reference to a name
 
-## 1.0.2 (2022-08-25)
+## [1.0.2] - 2022-08-25
+### Added
 - Serialize / deserialize settings
+### Changed
 - Improve error handling
 
-## 1.0.1 (2022-08-10) (released)
+## [1.0.1] - 2022-08-10
+### Changed
 - Clean code and file restructuring
 
-## 1.0.0 (2022-08-08) (released)
+## [1.0.0] - 2022-08-08
+### Added
 - Configuration of api endpoint
 - Opening data from api endpoint
+
+
+[1.1.0]: https://github.com/AdosH1/fanout-links/commit/f941f8fe4492c9ada26b73a92c386e814045dbc2
+[1.0.2]: https://github.com/AdosH1/fanout-links/commit/dc243b2732a9afb103dc8129ba184ed2e4f404a3
+[1.0.1]: https://github.com/AdosH1/fanout-links/commit/02c05f9f9ced31fb5dcb88da163323979bcd79bd
+[1.0.0]: https://github.com/AdosH1/fanout-links/commit/4746a876bbe8dd6f97f4a8971caf7db02381b2db

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Configuration of api endpoint
 - Opening data from api endpoint
 
-
+[1.2.0]: https://github.com/AdosH1/fanout-links/commit/491920675c5a6f87f2c76774d2df8e72b8c15ea5
 [1.1.0]: https://github.com/AdosH1/fanout-links/commit/f941f8fe4492c9ada26b73a92c386e814045dbc2
 [1.0.2]: https://github.com/AdosH1/fanout-links/commit/dc243b2732a9afb103dc8129ba184ed2e4f404a3
 [1.0.1]: https://github.com/AdosH1/fanout-links/commit/02c05f9f9ced31fb5dcb88da163323979bcd79bd

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "confy"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b1400cd0dae7f27d2c7ced9492e1398d2e2df614570092a4936c73b416dedea"
+dependencies = [
+ "directories",
+ "serde",
+ "toml",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -115,6 +126,15 @@ name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+
+[[package]]
+name = "directories"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc2561db021b6f1321d0f16b67ed28ce843ef4610dfaa432e3ffa2e8a3050ebf"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -140,6 +160,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "confy",
  "open",
  "reqwest",
  "serde",
@@ -923,6 +944,15 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "toml"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ tokio = { version = "1.20.1", features = ["full"] }
 serde = { version = "1.0.144", features = ["derive"] }
 serde_json = { version = "1.0" }
 anyhow = { version = "1.0.61"}
+confy = { version = "0.3.1" }

--- a/src/data/settings.rs
+++ b/src/data/settings.rs
@@ -6,3 +6,7 @@ pub struct Settings {
     pub api: Option<String>,
     pub custom_links: Option<HashMap<String, String>>,
 }
+
+impl ::std::default::Default for Settings {
+    fn default() -> Self { Self { api: None, custom_links: None } }
+}

--- a/src/io/file.rs
+++ b/src/io/file.rs
@@ -1,33 +1,14 @@
 use crate::data::settings::Settings;
-use crate::parse::settings::{from_config, to_config};
 use anyhow::Result;
-use std::env;
-use std::fs::File;
-use std::io::{Read, Write};
-use std::path::PathBuf;
 
-const CFG_NAME: &str = "fl.cfg";
+const CFG_NAME: &str = "fl.config";
 
-fn get_cfg_data(d: PathBuf) -> Result<String> {
-    let file_path = d.join(CFG_NAME);
-    let mut file = File::open(file_path)?;
-    let mut buf = String::new();
-    file.read_to_string(&mut buf)?;
-    Ok(buf)
+pub fn set_config(s: &Settings) -> Result<(), anyhow::Error> {
+    confy::store(CFG_NAME, &s)?;
+    Ok(())
 }
 
-pub fn set_config(s: &Settings) -> Result<()> {
-    let dir = env::temp_dir();
-    let file_path = dir.join(CFG_NAME);
-    let file_res = File::create(file_path);
-
-    let serialized = to_config(s)?;
-
-    Ok(writeln!(file_res?, "{serialized}")?)
-}
-
-pub fn get_config() -> Result<Settings> {
-    let dir = env::temp_dir();
-    let s = get_cfg_data(dir)?;
-    from_config(s)
+pub fn get_config() -> Result<Settings, anyhow::Error> {
+    let config : Settings = confy::load(CFG_NAME)?;
+    Ok(config)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,9 +14,12 @@ async fn main() {
     let args: Cli = Cli::parse();
     let mut config = match get_config() {
         Ok(s) => s,
-        Err(_) => Settings {
+        Err(_) => {
+            println!("An error went wrong loading config.. using default.");
+            Settings {
             api: None,
             custom_links: None,
+            }
         },
     };
 

--- a/src/parse/settings.rs
+++ b/src/parse/settings.rs
@@ -1,16 +1,4 @@
-use crate::data::settings::Settings;
-use anyhow::Result;
 use std::collections::HashMap;
-
-pub fn from_config(s: String) -> Result<Settings> {
-    let deserialized = serde_json::from_str(&s)?;
-    Ok(deserialized)
-}
-
-pub fn to_config(s: &Settings) -> Result<String> {
-    let serialized = serde_json::to_string(&s)?;
-    Ok(serialized)
-}
 
 pub fn add_custom_link(
     l: Option<HashMap<String, String>>,


### PR DESCRIPTION
Previously we were using a temp file for saving config, which happens to be cleaned by the OS pretty often.
This change uses a library that manages the saving / loading of configs based on the OS, simplifying our code.

Removed unused code and updated changelog